### PR TITLE
Migrate job execution to ThreadPoolExecutor + add robust cleanup + bugfixes

### DIFF
--- a/coldpress.py
+++ b/coldpress.py
@@ -133,7 +133,10 @@ class ColdpressShell(object):
                     log_job_msg(f"[STDERR] {line}")
         with job["lock"]:
             if job["status"] == "running":
-                job["status"] = "completed"
+                if not job["failed_tasks"]: 
+                    job["status"] = "completed"
+                else:
+                    job["status"] = "failed"
 
     def run_task(self, job, task):
         def log_job_msg(msg):


### PR DESCRIPTION
- Replaces the asyncio-based job queue worker with a ThreadPoolExecutor (1 worker per job) and tracks task Futures for status/stop handling. Upadted status function to use Futures for status tracking. 
- Adds explicit cleanup sequencing (`cleanup_job`) and ensures resources are cleaned on stop, failure, and shutdown; marks jobs failed when any tasks fail. 
-  Added the `shutdown_all` function
- Fixed bug in tracking the cleanup task
- Other minor bugs

Verified with all three examples. 

There is a known bug with error handling when the OpenShift API server cannot be reached. Will revisit after changes to the OpenShift python client and job handling. 